### PR TITLE
Fixed the stucked popover of the <kor-input type="select">

### DIFF
--- a/components/input/kor-input.ts
+++ b/components/input/kor-input.ts
@@ -393,17 +393,17 @@ export class korInput extends LitElement {
   }
 
   handleMenu() {
-    const self = this;
+    const parent = this.parentElement;
     // handle click outside of popover
-    const closePopover = function (e) {
-      if ((e.type === 'click' && e.target !== self) || e.type === 'wheel') {
-        self.active = false;
-        document.removeEventListener('click', closePopover);
-        document.removeEventListener('wheel', closePopover);
+    const closePopover = (e) => {
+      if ((e.type === 'click' && e.target !== this) || e.type === 'wheel') {
+        this.active = false;
+        parent.removeEventListener('click', closePopover);
+        parent.removeEventListener('wheel', closePopover);
       }
     };
-    document.addEventListener('click', closePopover);
-    document.addEventListener('wheel', closePopover);
+    parent.addEventListener('click', closePopover);
+    parent.addEventListener('wheel', closePopover);
   }
 
   validateMinMax(val) {


### PR DESCRIPTION
Hi Eduardo.

Thank you for the Great product - the kor-ui !

I had some troubles with the popover of  the `<kor-input type="select">`, when it is a child of the `<kor-modal>`, therefore I found and fixed the cause - the popover's listeners were bound to the document, while they should be bound to the kor-input's parent element.

Regards.