### PR TITLE
Fixed the bug preventing a kor-popover to appear on a target rendered at a shadowRoot

### DIFF
--- a/components/popover/kor-popover.ts
+++ b/components/popover/kor-popover.ts
@@ -170,10 +170,12 @@ export class korPopover extends LitElement {
   }
 
   addDocListener(tar) {
-    let self = this;
-    let closePopover = function (e) {
-      if ((e.target !== tar && e.type === 'click') || e.type === 'wheel') {
-        self.visible = false;
+    let closePopover = (e) => {
+      if ((e.composedPath()[0] != tar // if the target is rendered in a shadowRoot
+           && e.target !== tar && e.type === 'click')
+          || e.type === 'wheel')
+      {
+        this.visible = false;
         document.removeEventListener('click', closePopover);
         document.removeEventListener('wheel', closePopover);
       }


### PR DESCRIPTION
Hi Eduardo.

I've faced and fixed the bug preventing a kor-popover to appear on a target rendered at a shadowRoot.

I've packed an app menu in my own component and faced that issue: the `addDocListener(tar)` was unable to determine the click on the target as the `e.target == tar`, because `the e.target == <my-component>`, while `tar == my_component.shadowRoot.kor_icon`.

Therefore I've added a new condition `e.composedPath()[0] != tar &&` to the existent `e.target !== tar && e.type === 'click'`. 

While shadowRoot is open the `e.composedPath()[0]` will be the eventTarget from the target element.

Regards,
Vladimir.